### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,26 +5,26 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-MQTT				KEYWORD1
-MQTT_GPRSbee			KEYWORD1
+MQTT	KEYWORD1
+MQTT_GPRSbee	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-setServer			KEYWORD2
-setAuth				KEYWORD2
-setClientId			KEYWORD2
-setTransport			KEYWORD2
-publish				KEYWORD2
-close				KEYWORD2
+setServer	KEYWORD2
+setAuth	KEYWORD2
+setClientId	KEYWORD2
+setTransport	KEYWORD2
+publish	KEYWORD2
+close	KEYWORD2
 
 #######################################
 # Instances (KEYWORD3)
 #######################################
 
-mqtt				KEYWORD3
-mqtt_gprsbee			KEYWORD3
+mqtt	KEYWORD3
+mqtt_gprsbee	KEYWORD3
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords