### PR TITLE
Allow for connect and subscribe packets larger than 128 bytes

### DIFF
--- a/src/Sodaq_MQTT.h
+++ b/src/Sodaq_MQTT.h
@@ -98,6 +98,7 @@ private:
 
     uint32_t getRemainingLength(const uint8_t *buf, size_t & nrBytes);
     uint16_t get_uint16_be(const uint8_t *buf);
+    size_t writeRemainingLength(size_t length, uint8_t * &ptr);
 
     enum ControlPacketType_e {
         CPT_CONNECT = 1,


### PR DESCRIPTION
To connect to Azure IoT hub I needed a subscribe packet larger than 128 bytes as the username and password fields are quite large. 

It took me some time to figure out why it did not work, but in the end I discovered that the current implementation assumes that the connect (and subscribe packets too) are never larger than 128 bytes. I fixed it using the pseudocode found in the [MQTT docs](https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718023) 

Later on I discovered that there was already an implementation for the publish packet, I changed that too.